### PR TITLE
Fix compile error while running `cargo test`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! For example, to power on/off certain features, we can call `power_down`:
 //!
 //! ```
+//! # use wm8731::WM8731;
 //! WM8731::power_down(|c| {
 //!     c.line_input().enable();
 //!     c.adc().enable();


### PR DESCRIPTION
Doctests run as if they were a `fn main()` outside the crate, so they do
not have the crate's items in its namespace by default.

Without this, `cargo test` complains loudly:

    ---- src/lib.rs - (line 10) stdout ----
    error[E0433]: failed to resolve: use of undeclared type `WM8731`
     --> src/lib.rs:11:1
      |
    3 | WM8731::power_down(|c| {
      | ^^^^^^ not found in this scope
      |
    help: consider importing this struct
      |
    2 | use wm8731::WM8731;
      |

The `#` hides it from the documentation, so it does not have any effect
on the user-visible docs.