### PR TITLE
Make it compile with no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 //! });
 //! ```
 
+#![no_std]
+
 mod bitmask;
 
 pub mod enable_disable;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+extern crate std;
+
 use std::panic::catch_unwind;
 
 use crate::digital_audio_interface_format::{Format, Length};


### PR DESCRIPTION
This makes the bulk of the crate `no_std`, as the only `std` item needed
so far is the `catch_unwind` in the unit tests.

This also makes it fail to compile tests if something from `std` is
accidentally used outside of the `tests` module.